### PR TITLE
Updating rules_foreign_cc repository to no longer use deprecated bazel_tools platform code

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,14 @@
 workspace(name = "rules_foreign_cc")
 
+http_archive(
+    name = "platforms",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
+    ],
+    sha256 = "5eda539c841265031c2f82d8ae7a3a6490bd62176e0c038fc469eabf91f6149b",
+)
+
 load("//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
 
 rules_foreign_cc_dependencies([

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -83,8 +83,8 @@ sh_test(
 toolchain(
     name = "built_cmake_toolchain",
     exec_compatible_with = [
-        "@bazel_tools//platforms:osx",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:osx",
+        "@platforms//cpu:x86_64",
     ],
     toolchain = "@rules_foreign_cc//tools/build_defs/native_tools:built_cmake",
     toolchain_type = "@rules_foreign_cc//tools/build_defs:cmake_toolchain",
@@ -94,8 +94,8 @@ toolchain(
 toolchain(
     name = "built_ninja_toolchain_osx",
     exec_compatible_with = [
-        "@bazel_tools//platforms:osx",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:osx",
+        "@platforms//cpu:x86_64",
     ],
     toolchain = "@rules_foreign_cc//tools/build_defs/native_tools:built_ninja",
     toolchain_type = "@rules_foreign_cc//tools/build_defs:ninja_toolchain",
@@ -104,8 +104,8 @@ toolchain(
 toolchain(
     name = "built_ninja_toolchain_linux",
     exec_compatible_with = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
     ],
     toolchain = "@rules_foreign_cc//tools/build_defs/native_tools:built_ninja",
     toolchain_type = "@rules_foreign_cc//tools/build_defs:ninja_toolchain",

--- a/toolchains_examples/BUILD
+++ b/toolchains_examples/BUILD
@@ -20,8 +20,8 @@ constraint_value(
 platform(
     name = "fancy_platform",
     constraint_values = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
         ":fancy_constraint_value",
     ],
 )

--- a/toolchains_examples/WORKSPACE
+++ b/toolchains_examples/WORKSPACE
@@ -1,5 +1,15 @@
 workspace(name = "rules_foreign_cc_toolchains_examples")
 
+#-------------------------------------------------------------------------------
+http_archive(
+    name = "platforms",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
+    ],
+    sha256 = "5eda539c841265031c2f82d8ae7a3a6490bd62176e0c038fc469eabf91f6149b",
+)
+
 local_repository(
     name = "rules_foreign_cc",
     path = "..",

--- a/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl
@@ -1,6 +1,6 @@
 load("@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:function_and_call.bzl", "FunctionAndCall")
 
-_REPLACE_VALUE = "\${EXT_BUILD_DEPS}"
+_REPLACE_VALUE = "\\${EXT_BUILD_DEPS}"
 
 def os_name():
     return "linux"
@@ -55,8 +55,8 @@ def define_function(name, text):
 def replace_in_files(dir, from_, to_):
     return FunctionAndCall(
         text = """if [ -d "$1" ]; then
-  find -L $1 -type f \
-  \( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \) \
+  find -L $1 -type f \\
+  \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \\) \\
   -exec sed -i 's@'"$2"'@'"$3"'@g' {} ';'
 fi
 """,

--- a/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl
@@ -1,6 +1,6 @@
 load("@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:function_and_call.bzl", "FunctionAndCall")
 
-_REPLACE_VALUE = "\${EXT_BUILD_DEPS}"
+_REPLACE_VALUE = "\\${EXT_BUILD_DEPS}"
 
 def os_name():
     return "linux"
@@ -55,8 +55,8 @@ def define_function(name, text):
 def replace_in_files(dir, from_, to_):
     return FunctionAndCall(
         text = """if [ -d "$1" ]; then
-  find -L $1 -type f \
-  \( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \) \
+  find -L $1 -type f \\
+  \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \\) \\
   -exec sed -i 's@'"$2"'@'"$3"'@g' {} ';'
 fi
 """,

--- a/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
@@ -1,6 +1,6 @@
 load("@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:function_and_call.bzl", "FunctionAndCall")
 
-_REPLACE_VALUE = "\${EXT_BUILD_DEPS}"
+_REPLACE_VALUE = "\\${EXT_BUILD_DEPS}"
 
 def os_name():
     return "osx"
@@ -55,7 +55,7 @@ def define_function(name, text):
 def replace_in_files(dir, from_, to_):
     return FunctionAndCall(
         text = """if [ -d "$1" ]; then
-    find -L -f $1 \( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \) \
+    find -L -f $1 \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \\) \\
     -exec sed -i -e 's@'"$2"'@'"$3"'@g' {} ';'
 fi
 """,

--- a/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
@@ -1,6 +1,6 @@
 load("@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:function_and_call.bzl", "FunctionAndCall")
 
-_REPLACE_VALUE = "\${EXT_BUILD_DEPS}"
+_REPLACE_VALUE = "\\${EXT_BUILD_DEPS}"
 
 def os_name():
     return "windows"
@@ -55,8 +55,8 @@ def define_function(name, text):
 def replace_in_files(dir, from_, to_):
     return FunctionAndCall(
         text = """if [ -d "$1" ]; then
-  $REAL_FIND -L $1 -type f \
-  \( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \) \
+  $REAL_FIND -L $1 -type f \\
+  \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \\) \\
   -exec sed -i 's@'"$2"'@'"$3"'@g' {} ';'
 fi
 """,

--- a/tools/build_defs/shell_toolchain/toolchains/toolchain_mappings.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/toolchain_mappings.bzl
@@ -10,22 +10,22 @@ ToolchainMapping = provider(
 TOOLCHAIN_MAPPINGS = [
     ToolchainMapping(
         exec_compatible_with = [
-            "@bazel_tools//platforms:linux",
-            "@bazel_tools//platforms:x86_64",
+            "@platforms//os:linux",
+            "@platforms//cpu:x86_64",
         ],
         file = "@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains/impl:linux_commands.bzl",
     ),
     ToolchainMapping(
         exec_compatible_with = [
-            "@bazel_tools//platforms:windows",
-            "@bazel_tools//platforms:x86_64",
+            "@platforms//os:windows",
+            "@platforms//cpu:x86_64",
         ],
         file = "@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains/impl:windows_commands.bzl",
     ),
     ToolchainMapping(
         exec_compatible_with = [
-            "@bazel_tools//platforms:osx",
-            "@bazel_tools//platforms:x86_64",
+            "@platforms//os:osx",
+            "@platforms//cpu:x86_64",
         ],
         file = "@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains/impl:osx_commands.bzl",
     ),


### PR DESCRIPTION
# Changes
- Added the bazel platforms into the WORKSPACE
- Updated different BUILD files and bzl files to use platforms// instead of bazel_tools//platforms
- Update the toolchain platform bzl files to use a double backslash instead of a single backslash